### PR TITLE
Added a method to retrieve a key from the Keychain for an identifier

### DIFF
--- a/Classes/UYLPasswordManager.h
+++ b/Classes/UYLPasswordManager.h
@@ -53,9 +53,11 @@ typedef enum _UYLPMAccessMode {
 - (void)registerKey:(NSString *)key forIdentifier:(NSString *)identifier inGroup:(NSString *)group;
 - (void)deleteKeyForIdentifier:(NSString *)identifier inGroup:(NSString *)group;
 - (BOOL)validKey:(NSString *)key forIdentifier:(NSString *)identifier inGroup:(NSString *)group;
+- (NSString *)keyForIdentifier:(NSString *)identifier inGroup:(NSString *)group;
 
 - (void)registerKey:(NSString *)key forIdentifier:(NSString *)identifier;
 - (void)deleteKeyForIdentifier:(NSString *)identifier;
 - (BOOL)validKey:(NSString *)key forIdentifier:(NSString *)identifier;
+- (NSString *)keyForIdentifier:(NSString *)identifier;
 
 @end

--- a/Classes/UYLPasswordManager.m
+++ b/Classes/UYLPasswordManager.m
@@ -339,6 +339,17 @@ static UYLPasswordManager *_sharedInstance = nil;
 	return result;
 }
 
+- (NSString *)keyForIdentifier:(NSString *)identifier inGroup:(NSString *)group {
+    if (identifier) {
+        self.keychainAccessGroup = group;
+        self.keychainIdentifier = identifier;
+        [self searchKeychain];
+        return self.keychainValue;
+    } else {
+        return nil;
+    }
+}
+
 - (void)deleteKeyForIdentifier:(NSString *)identifier inGroup:(NSString *)group {
 
     self.keychainAccessGroup = group;
@@ -357,6 +368,11 @@ static UYLPasswordManager *_sharedInstance = nil;
 - (BOOL)validKey:(NSString *)key forIdentifier:(NSString *)identifier {
     BOOL result = [self validKey:key forIdentifier:identifier inGroup:nil];
 	return result;
+}
+
+- (NSString *)keyForIdentifier:(NSString *)identifier {
+    NSString *result = [self keyForIdentifier:identifier inGroup:nil];
+  return result;
 }
 
 @end

--- a/README.markdown
+++ b/README.markdown
@@ -46,6 +46,16 @@ For example, to store a password you might use the user name as the identifier.
 
     [manager registerKey:password forIdentifier:username];
 
+Retrieving an Item from the Keychain
+---------------------
+
+To retrieve a key for an identifier:
+
+    NSString *result = [manager keyForIdentifier:username];
+
+If there is no matching identifier in the Keychain this will return nil.
+
+
 Searching for an Item
 ---------------------
 
@@ -113,7 +123,7 @@ You then need to add an entitlements plist file to the Xcode project (use Add ->
 Accessing a Keychain Group
 --------------------------
 
-The UYLPasswordManager methods for adding and searching for keychain items are all available in a form that takes an additional group parameter:
+The UYLPasswordManager methods for adding, retrieving, and searching for keychain items are all available in a form that takes an additional group parameter:
 
     [manager registerKey:password forIdentifier:username inGroup:group];
 


### PR DESCRIPTION
I have a use case where I want to store an API token in the keychain after a user has authenticated. This API token is then used for requests from the app to the API. I wanted to be able to query the keychain for the API token identifier and retrieve the token. If the token does not exist then prompt the user to login again to get a new token.
